### PR TITLE
Simultaneous batch substituions for Tensor.subst_all

### DIFF
--- a/drudge/drudge.py
+++ b/drudge/drudge.py
@@ -979,7 +979,9 @@ class Tensor:
                     raise TypeError('Expecting Symbol or IndexedBase')
 
                 if name.endswith(_DECR_SUFFIX):
-                    restore_vars[var] = Ref(name[:suffix_index])
+                    restore_vars[var] = Ref(
+                        name[:suffix_index], **var._assumptions
+                    )
 
         func = lambda x: x.xreplace(restore_vars)
 
@@ -1197,9 +1199,13 @@ class Tensor:
             # wilds            for var in free_vars:
             for var in free_vars:
                 if isinstance(var, Symbol):
-                    decr_vars[var] = Symbol(var.name + _DECR_SUFFIX)
+                    decr_vars[var] = Symbol(
+                        var.name + _DECR_SUFFIX, **var._assumptions
+                    )
                 elif isinstance(var, IndexedBase):
-                    decr_vars[var] = IndexedBase(var.label.name + _DECR_SUFFIX)
+                    decr_vars[var] = IndexedBase(
+                        var.label.name + _DECR_SUFFIX, **var._assumptions
+                    )
                 else:
                     raise TypeError('Expecting Symbol or IndexedBase')
 

--- a/drudge/term.py
+++ b/drudge/term.py
@@ -802,7 +802,7 @@ class Term(ATerms):
 
         res_vecs = self._vecs if vecs is None else vecs
         if not skip_vecs:
-            res_vecs = tuple(i.map(func) for i in res_vecs)
+            res_vecs = tuple(vec.map(func) for vec in res_vecs)
 
         return Term(res_sums, res_amp, res_vecs)
 
@@ -820,7 +820,7 @@ class Term(ATerms):
         if sums is None:
             sums = self._sums
         if purge_sums:
-            sums = tuple(i for i in sums if i[0] not in substs)
+            sums = tuple(sum_ for sum_ in sums if sum_[0] not in substs)
 
         return self.map(
             lambda x: x.xreplace(substs), sums=sums, amp=amp, vecs=vecs,

--- a/tests/free_algebra_test.py
+++ b/tests/free_algebra_test.py
@@ -12,7 +12,9 @@ from sympy import (
     Rational, Symbol, Function
 )
 
-from drudge import Drudge, Range, Vec, Term, Perm, NEG, CONJ, TensorDef
+from drudge import (
+    Drudge, Range, Vec, Term, Perm, NEG, CONJ, TensorDef, CR, UP, DOWN
+)
 
 
 @pytest.fixture(scope='module')
@@ -881,6 +883,81 @@ def test_tensors_can_be_substituted_strings_of_vectors(
     orig = dr.einst(x[i, j] * v[i] * v[j])
     res = orig.subst(v[i] * v[i], vivi_def)
     assert res == orig
+
+
+@pytest.mark.parametrize('full_balance', [True, False])
+@pytest.mark.parametrize('simplify', [True, False])
+def test_batch_vector_substitutions(
+        free_alg, full_balance, simplify
+):
+    """Test the batch substitutions using the subst_all method
+    """
+
+    dr = free_alg
+    p = dr.names
+
+    a = IndexedBase('a')
+    x = IndexedBase('x')
+    y = IndexedBase('y')
+    i, j = p.i, p.j
+    v = p.v
+    v_dag = Vec('v', indices=(CR,))
+
+    #
+    # Spin flipping
+    #
+
+    orig1 = dr.sum((i, p.R), (j, p.R), a[i, j] * v[i, UP] * v[j, DOWN])
+    defs1 = [
+        dr.define(v[i, UP], v[i, DOWN]), dr.define(v[i, DOWN], v[i, UP])
+    ]
+
+    # Sequentially apply the definitions of the substitutions
+    expected_sequential = dr.sum(
+        (i, p.R), (j, p.R), a[i, j] * v[i, UP] * v[j, UP]
+    )
+    res = orig1.subst_all(
+        defs1, simult_all=False, full_balance=full_balance, simplify=simplify
+    )
+    assert res == expected_sequential
+
+    # Simultaneously apply the definitions of the substitutions
+    expected_simutaneous = dr.sum(
+        (i, p.R), (j, p.R), a[i, j] * v[i, DOWN] * v[j, UP]
+    )
+    res = orig1.subst_all(
+        defs1, simult_all=True, full_balance=full_balance, simplify=simplify
+    )
+    assert res == expected_simutaneous
+
+    #
+    # In-place BCS transformation
+    #
+
+    orig2 = dr.einst(
+        a[i, j] * v_dag[i, UP] * v[j, UP] +
+        a[i, j] * v_dag[i, DOWN] * v[j, DOWN]
+    )
+    defs2 = [
+        dr.define(v_dag[i, UP], x[i] * v_dag[i, UP] - y[i] * v[i, DOWN]),
+        dr.define(v_dag[i, DOWN], x[i] * v_dag[i, DOWN] + y[i] * v[i, UP]),
+        dr.define(v[i, UP], x[i] * v[i, UP] - y[i] * v_dag[i, DOWN]),
+        dr.define(v[i, DOWN], x[i] * v[i, DOWN] + y[i] * v_dag[i, UP]),
+    ]
+
+    # Simultaneously apply the definitions of the substitutions
+    expected = dr.sum(
+        (i, p.R), (j, p.R), a[i, j] * (
+            (x[i] * v_dag[i, UP] - y[i] * v[i, DOWN])
+            * (x[j] * v[j, UP] - y[j] * v_dag[j, DOWN])
+            + (x[i] * v_dag[i, DOWN] + y[i] * v[i, UP])
+            * (x[j] * v[j, DOWN] + y[j] * v_dag[j, UP])
+        )
+    ).simplify()
+    res = orig2.subst_all(
+        defs2, simult_all=True, full_balance=full_balance, simplify=simplify
+    ).simplify()
+    assert res == expected
 
 
 def test_special_substitution_of_identity(free_alg):

--- a/tests/nuclear_test.py
+++ b/tests/nuclear_test.py
@@ -214,7 +214,8 @@ def test_wigner3j_sum_to_wigner6j(nuclear: NuclearBogoliubovDrudge):
     term = res.local_terms[0]
     assert len(term.sums) == 0
     assert len(term.vecs) == 0
-    assert (term.amp - expected).simplify() == 0
+    difference = (res - dr.sum(expected)).deep_simplify()
+    assert len(difference.local_terms) == 0
 
 
 @pytest.mark.skip(reason='Pending improvement in PONO simplification')


### PR DESCRIPTION
A new a argument, ``simult_all``, is added to Tensor.subst_all, which facilitates substituting with all ``TensorDef`` instances in a list independently of their order. By default, ``simult_all`` is set to be false, so the new feature does not affect existing drudge functionalities. Tests are added, which can also serve as code examples.